### PR TITLE
Add blurb about unofficial image

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ docker build -t fokus .
 docker run -d --name fokus -p 5000:5000 fokus
 ```
 
+NOTE: There is also an unofficially maintained docker image available at `registry.gitlab.com/brandonbutler/fokus-docker:latest`, see the [fokus-docker](https://gitlab.com/brandonbutler/fokus-docker) project for more information.
+
 <br>
 
 # Contributing


### PR DESCRIPTION
See #5 . This is an unofficially maintained docker image for the project, but adds some convenience to users who prefer docker environments to setup with. In my opinion, the preferred route would be for you to own the image, but I'm understanding that Docker is currently outside your skillset :) Hopefully this works as a stop-gap.